### PR TITLE
Save last parsed deal time over last parsed deal name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Prerequisites:
   - Have set the above environment variables locally in a `.env` file
 
 Running:
+  - `npm install`
   - `serverless deploy`
 
 Removing:


### PR DESCRIPTION
If the last stored deal was deleted after saving it, reddits API no longer returns post `?before=it` in the new posts call and everything breaks.

Instead save the last parsed deal create data and use that to get recent deals